### PR TITLE
fix: removed the .1 from the version

### DIFF
--- a/nord.omp.json
+++ b/nord.omp.json
@@ -152,5 +152,5 @@
       "type": "prompt"
     }
   ],
-  "version": 2.1
+  "version": 2
 }


### PR DESCRIPTION
solved issue with new omp version not detecting the theme's version